### PR TITLE
Optimise upgrade step 2022072200

### DIFF
--- a/classes/task/upgrade_single_course.php
+++ b/classes/task/upgrade_single_course.php
@@ -1,0 +1,93 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace format_grid\task;
+
+/**
+ * Class upgrade_single_course
+ *
+ * @package    format_grid
+ * @copyright  2023 YOUR NAME <your@email.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class upgrade_single_course extends \core\task\adhoc_task {
+
+    public function get_name(){
+        return "Course Format Grid Image Migration - 3.9 to 4.1";
+    }
+    
+    public function execute(){
+        $params = $this->get_custom_data();
+
+        $courseid = $params->courseid;
+
+        $this->upgrade_course($courseid);
+    }
+
+    private function upgrade_course($currentcourseid){
+        global $DB;
+    
+        $newimagecoursearray = $DB->get_records_sql(
+            'SELECT sectionid, courseid, image, displayedimagestate FROM {format_grid_image} WHERE courseid = ?',
+            [$currentcourseid]
+        );
+        $fs = get_file_storage();
+        $coursecontext = \context_course::instance($currentcourseid);
+        $files = $fs->get_area_files($coursecontext->id, 'course', 'section');
+        foreach ($files as $file) {
+            if (!$file->is_directory()) {
+                if ($file->get_filepath() == '/gridimage/') {
+                    $file->delete();
+                } else {
+                    $filename = $file->get_filename();
+                    $filesectionid = $file->get_itemid();
+                    // Ensure we know about this section.
+                    if (array_key_exists($filesectionid, $newimagecoursearray)) {
+                        $gridimage = $newimagecoursearray[$filesectionid];
+                        // Ensure the correct file.
+                        if (($gridimage) && ($gridimage->image == $filename)) {
+                            $filerecord = new \stdClass();
+                            $filerecord->contextid = $coursecontext->id;
+                            $filerecord->component = 'format_grid';
+                            $filerecord->filearea = 'sectionimage';
+                            $filerecord->itemid = $filesectionid;
+                            $filerecord->filepath = '/';
+                            $filerecord->filename = $filename;
+                            $thefile = false;
+                            // Check to see if the file is already there.
+                            $thefile = $fs->get_file(
+                                $filerecord->contextid,
+                                $filerecord->component,
+                                $filerecord->filearea,
+                                $filerecord->itemid,
+                                $filerecord->filepath,
+                                $filerecord->filename);
+                            if ($thefile === false) {
+                                $thefile = $fs->create_file_from_storedfile($filerecord, $file);
+                            }
+                            if ($thefile !== false) {
+                                $DB->set_field('format_grid_image', 'contenthash',
+                                    $thefile->get_contenthash(), ['sectionid' => $filesectionid]);
+                                // Don't delete the section file in case used in the summary.
+                            }
+    
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/classes/task/upgrade_single_course.php
+++ b/classes/task/upgrade_single_course.php
@@ -25,21 +25,18 @@ namespace format_grid\task;
  */
 class upgrade_single_course extends \core\task\adhoc_task {
 
-    public function get_name(){
+    public function get_name() {
         return "Course Format Grid Image Migration - 3.9 to 4.1";
     }
-    
-    public function execute(){
+
+    public function execute() {
         $params = $this->get_custom_data();
-
         $courseid = $params->courseid;
-
         $this->upgrade_course($courseid);
     }
 
-    private function upgrade_course($currentcourseid){
+    private function upgrade_course($currentcourseid) {
         global $DB;
-    
         $newimagecoursearray = $DB->get_records_sql(
             'SELECT sectionid, courseid, image, displayedimagestate FROM {format_grid_image} WHERE courseid = ?',
             [$currentcourseid]
@@ -83,7 +80,6 @@ class upgrade_single_course extends \core\task\adhoc_task {
                                     $thefile->get_contenthash(), ['sectionid' => $filesectionid]);
                                 // Don't delete the section file in case used in the summary.
                             }
-    
                         }
                     }
                 }

--- a/classes/task/upgrade_single_course.php
+++ b/classes/task/upgrade_single_course.php
@@ -20,7 +20,7 @@ namespace format_grid\task;
  * Class upgrade_single_course
  *
  * @package    format_grid
- * @copyright  2023 YOUR NAME <your@email.com>
+ * @copyright  2023 Jay Oswad <jayoswald@catalyst-au.net>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class upgrade_single_course extends \core\task\adhoc_task {

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -73,22 +73,19 @@ function xmldb_format_grid_upgrade($oldversion = 0) {
                     $oldimages = $DB->get_records('format_grid_icon');
                     if (!empty($oldimages)) {
                         if ($dbman->table_exists($oldtable)) {
-                
-                            //Move images
+                            // Move images.
                             $DB->execute('
                             INSERT INTO {format_grid_image} (sectionid, courseid, image, displayedimagestate)
                             SELECT sectionid, courseid, image, 0
                             FROM {format_grid_icon}
                             WHERE courseid IN ( SELECT id FROM {course} )
                             ');
-            
                             $courses = $DB->get_records_sql('SELECT DISTINCT courseid FROM {format_grid_image}');
-                            foreach($courses as $course){
+                            foreach ($courses as $course) {
                                 $task = new \format_grid\task\upgrade_single_course();
                                 $task->set_custom_data([
                                     'course_id' => $course->courseid,
                                 ]);
-            
                                 \core\task\manager::queue_adhoc_task($task, true);
                             }
                         }

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -76,10 +76,10 @@ function xmldb_format_grid_upgrade($oldversion = 0) {
                 
                             //Move images
                             $DB->execute('
-                            INSERT INTO mdl_format_grid_image (sectionid, courseid, image, displayedimagestate)
+                            INSERT INTO {format_grid_image} (sectionid, courseid, image, displayedimagestate)
                             SELECT sectionid, courseid, image, 0
-                            FROM mdl_format_grid_icon
-                            WHERE courseid IN ( SELECT id FROM mdl_course )
+                            FROM {format_grid_icon}
+                            WHERE courseid IN ( SELECT id FROM {course} )
                             ');
             
                             $courses = $DB->get_records_sql('SELECT DISTINCT courseid FROM {format_grid_image}');


### PR DESCRIPTION
Optimising upgrade step `2022072200`

On the site that I have been working on this upgrade step was taking 3-3.5 hours to run, after these changes it takes about 3 minutes, and an extra asynchronous hour. The original code also uses a lot of memory as it loads the entire database table into memory twice, this new step skips that entirely.

The first loop took about 40 mins to run, this was replaced by a single SQL query which achieved the same results and only takes a few seconds to run.

The 2nd loop was replaced by the use of adhoc tasks. It migrated the images to the new format. This can run in the background, the only downside is the images can be broken while the script is running. However instead of it taking almost 3 hours to run, it takes a few minutes to add the adhoc tasks, then after the upgrade is done the adhoc tasks took just under an hour, as the adhoc tasks can run in parallel. On a more powerful production server where more tasks can run in parallel the time savings are even greater.
