### PR TITLE
Fix availability info display

### DIFF
--- a/templates/grid.mustache
+++ b/templates/grid.mustache
@@ -88,11 +88,6 @@
                     {{/ core_courseformat/local/content/section/badges }}
                 </div>
             {{/notavailable}}</div>
-            {{#availability}}
-                {{$ core_courseformat/local/content/section/availability }}
-                    {{> core_courseformat/local/content/section/availability }}
-                {{/ core_courseformat/local/content/section/availability }}
-            {{/availability}}
             {{#imageuri}}
             <div class="grid-image card-img-bottom text-center">
                 <img src="{{imageuri}}" alt="{{imagealttext}}" loading="lazy">
@@ -111,6 +106,11 @@
         {{#popup}}
         </div>
         {{/popup}}
+        {{#availability}}
+            {{$ core_courseformat/local/content/section/availability }}
+                {{> core_courseformat/local/content/section/availability }}
+            {{/ core_courseformat/local/content/section/availability }}
+        {{/availability}}
     </li>
     {{/gridsections}}
 </ul>


### PR DESCRIPTION
This change cleans up the display when restrictions are set. E.g. currently displays as 
![2024-05-22_11-21](https://github.com/catalyst/moodle-format_grid/assets/63634595/58659d1d-3eb7-40c4-ab4e-5c07913c8c1f)

With this is change it will look like
![2024-05-22_11-20](https://github.com/catalyst/moodle-format_grid/assets/63634595/377c0ef1-6af6-4bad-b918-544484d2d6e2)
